### PR TITLE
Build and publish containers to private ECR repo

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,0 +1,48 @@
+name: ECR
+
+on:
+  release:
+    types:
+      - published
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+    branches:
+      - main
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/heyfil:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The reported status of a state market participants are:
 | status              | Description                                                                                                                         |
 |---------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `ok`                | Participant is an index provider with non-empty head successfully announced to IPNI.                                                |
-| `err-api-call`      | Failure occurred while calling the FileCoin API caused bo communication error.                                                      |
+| `err-api-call`      | Failure occurred while calling the FileCoin API caused by communication error.                                                      |
 | `err-internal`      | Failed to get participant's address which was not a communication or RPC error response.                                            |
 | `err-rpc-unknown`   | Failed to get participant's address caused by RPC error response.                                                                   |
 | `not-miner`         | The participant is not a miner.                                                                                                     |


### PR DESCRIPTION
Build and publish `heyfil` service containers onto a private ECR repo
used to deploy the service onto K8S clusters.