### PR TITLE
Fetch state market deals from `filecoin.tools` and refine error kinds

### DIFF
--- a/fil_deal_stats.go
+++ b/fil_deal_stats.go
@@ -33,7 +33,7 @@ func (ds *dealStats) refresh(ctx context.Context) error {
 	}
 	epoch := ch.Height
 
-	deals, err := ds.hf.stateMarketDeals(ctx)
+	deals, err := ds.hf.stateMarketDealsViaFilTools(ctx)
 	if err != nil {
 		return err
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -168,7 +168,7 @@ func (m *metrics) snapshot(targets map[string]*Target) {
 
 	for _, t := range targets {
 		countsByStatus[t.Status] = countsByStatus[t.Status] + 1
-		if t.AddrInfo != nil {
+		if t.AddrInfo.ID != "" && len(t.AddrInfo.Addrs) > 0 {
 			if t.DealCount > 0 {
 				if t.KnownByIndexer {
 					totalParticipantsKnownByIndexer++
@@ -227,6 +227,10 @@ func targetStatusToAttribute(s Status) attribute.KeyValue {
 		value = "unreachable"
 	case StatusUnaddressable:
 		value = "unaddressable"
+	case StatusUnidentifiable:
+		value = "unidentifiable"
+	case StatusNoAddrInfo:
+		value = "no-addrinfo"
 	case StatusUnindexed:
 		value = "unindexed"
 	case StatusTopicMismatch:

--- a/options.go
+++ b/options.go
@@ -22,7 +22,8 @@ type (
 		snapshotInterval              *time.Ticker
 		serverListenAddr              string
 		httpClient                    *http.Client
-		marketDealsAlt                string
+		marketDealsS3Snapshot         string
+		marketDealsFilTools           string
 		httpIndexerEndpoint           string
 	}
 )
@@ -30,7 +31,8 @@ type (
 func newOptions(o ...Option) (*options, error) {
 	opts := &options{
 		api:                           `https://api.node.glif.io`,
-		marketDealsAlt:                `https://marketdeals.s3.amazonaws.com/StateMarketDeals.json`,
+		marketDealsS3Snapshot:         `https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst`,
+		marketDealsFilTools:           `https://filecoin.tools/api/deals/list`,
 		httpIndexerEndpoint:           `https://cid.contact`,
 		httpClient:                    http.DefaultClient,
 		maxConcurrentParticipantCheck: 10,


### PR DESCRIPTION
The old S3 endpoint seems to have been deprecated. Instead, a new endpoint exists that now offers the same data but in ZST compressed format. This would most likely require intermediate download and decompression of file before it can be processed.

As an alternative, fetch the state markets deal data from `filecoin.tools` API.

Implement dedicated error kinds to differentiate between absent multiaddrs and peer ID. The new error kinds now use `unaddressable` when addrs are missing, `unidentifiable` when peer ID is missing, and `no-addrinfo` when both are missing.

Relates to:
 - https://github.com/ipni/heyfil/issues/12