### PR TITLE
Implement deal coverage stats by time span

### DIFF
--- a/fil_client.go
+++ b/fil_client.go
@@ -34,8 +34,9 @@ type (
 	}
 	StateMarketDeal struct {
 		Proposal struct {
-			Provider string `json:"Provider"`
-			EndEpoch int64  `json:"EndEpoch"`
+			Provider   string `json:"Provider"`
+			StartEpoch int64  `json:"StartEpoch"`
+			EndEpoch   int64  `json:"EndEpoch"`
 		} `json:"Proposal"`
 		State struct {
 			SectorStartEpoch int64 `json:"SectorStartEpoch"`

--- a/target.go
+++ b/target.go
@@ -23,7 +23,10 @@ type (
 		HeadProtocol   protocol.ID
 		Head           cid.Cid
 		KnownByIndexer bool
-		DealCount      int64
+
+		DealCount           int64
+		DealCountWithinDay  int64
+		DealCountWithinWeek int64
 	}
 )
 
@@ -48,7 +51,11 @@ const (
 func (t *Target) check(ctx context.Context) *Target {
 	defer func() { t.LastChecked = time.Now() }()
 	logger := logger.With("miner", t.ID)
-	t.DealCount = t.hf.dealStats.getDealCount(t.ID)
+
+	counts := t.hf.dealStats.getDealCounts(t.ID)
+	t.DealCount = counts.count
+	t.DealCountWithinDay = counts.countWithinDay
+	t.DealCountWithinWeek = counts.countWithinWeek
 
 	// Get address for miner ID from FileCoin API.
 	t.AddrInfo, t.Err = t.hf.stateMinerInfo(ctx, t.ID)


### PR DESCRIPTION
Add metrics that expose total deals made within the last day and within the last week, qualified by whether their provider is known by a configured indexer or not.

These metrics would then allow us to reason about the proportion of deals covered by IPNI relative to their age.