### PR TITLE
Implement query API with filtering by SP libp2p peer ID

### DIFF
--- a/api_server.go
+++ b/api_server.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func (hf *heyFil) startApiServer() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc(`/sp`, hf.handleSPRoot)
+	mux.HandleFunc(`/sp/`, hf.handleSPSubtree)
+	mux.HandleFunc(`/`, handleDefault)
+	hf.apiServer = http.Server{
+		Addr:    hf.apiListenAddr,
+		Handler: mux,
+	}
+	go func() {
+		err := hf.apiServer.ListenAndServe()
+		switch {
+		case errors.Is(err, http.ErrServerClosed):
+			logger.Info("server stopped")
+		default:
+			logger.Infow("server failed", "")
+		}
+	}()
+	return nil
+}
+
+func (hf *heyFil) handleSPRoot(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodOptions:
+		w.Header().Set(httpHeaderAllow(http.MethodGet, http.MethodOptions))
+	case http.MethodGet:
+		pid := r.URL.Query().Get("peerid")
+		filterByPeerID := pid != ""
+		var pidFilter peer.ID
+		if filterByPeerID {
+			var err error
+			pidFilter, err = peer.Decode(pid)
+			if err != nil {
+				http.Error(w, `The "peerid" query parameter is not a valid peer ID`, http.StatusBadRequest)
+				return
+			}
+		}
+		hf.targetsMutex.RLock()
+		spIDs := make([]string, 0, len(hf.targets))
+		for id, target := range hf.targets {
+			if filterByPeerID && target.AddrInfo.ID != pidFilter {
+				continue
+			}
+			spIDs = append(spIDs, id)
+		}
+		sort.Strings(spIDs)
+		hf.targetsMutex.RUnlock()
+		if err := json.NewEncoder(w).Encode(spIDs); err != nil {
+			logger.Errorw("Failed to encode SP IDs", "err", err)
+		}
+	default:
+		hf.respondWithNotAllowed(w, http.MethodGet, http.MethodOptions)
+	}
+}
+
+func (hf *heyFil) handleSPSubtree(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodOptions:
+		w.Header().Set(httpHeaderAllow(http.MethodGet, http.MethodOptions))
+	case http.MethodGet:
+		pathSuffix := strings.TrimPrefix(r.URL.Path, "/sp/")
+		switch segments := strings.SplitN(pathSuffix, "/", 3); len(segments) {
+		case 1:
+			id := segments[0]
+			if id == "" {
+				// Path does not contain SP ID.
+				http.Error(w, "SP ID must be specified as URL parameter", http.StatusBadRequest)
+			} else {
+				hf.handleGetSP(w, id)
+			}
+		default:
+			// Path has multiple segments and therefore 404
+			http.NotFound(w, r)
+		}
+	default:
+		hf.respondWithNotAllowed(w, http.MethodGet, http.MethodOptions)
+	}
+}
+
+func (hf *heyFil) handleGetSP(w http.ResponseWriter, id string) {
+	hf.targetsMutex.RLock()
+	target, ok := hf.targets[id]
+	hf.targetsMutex.RUnlock()
+	if !ok {
+		http.Error(w, "SP not found", http.StatusNotFound)
+	} else if err := json.NewEncoder(w).Encode(target); err != nil {
+		logger.Errorw("Failed to encode SP info", "id", id, "err", err)
+	}
+}
+
+func handleDefault(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodOptions:
+		w.Header().Set(httpHeaderAllow(http.MethodOptions))
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func httpHeaderAllow(methods ...string) (string, string) {
+	return "Allow", strings.Join(methods, ",")
+}
+
+func (hf *heyFil) respondWithNotAllowed(w http.ResponseWriter, allowedMethods ...string) {
+	w.Header().Set(httpHeaderAllow(allowedMethods...))
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+func (hf *heyFil) shutdownApiServer(ctx context.Context) error {
+	return hf.apiServer.Shutdown(ctx)
+}

--- a/metrics_server.go
+++ b/metrics_server.go
@@ -8,15 +8,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func (hf *heyFil) startServer() error {
+func (hf *heyFil) startMetricsServer() error {
 	mux := http.NewServeMux()
 	mux.Handle(`/metrics`, promhttp.Handler())
-	hf.server = http.Server{
-		Addr:    hf.serverListenAddr,
+	hf.metricsServer = http.Server{
+		Addr:    hf.metricsListenAddr,
 		Handler: mux,
 	}
 	go func() {
-		err := hf.server.ListenAndServe()
+		err := hf.metricsServer.ListenAndServe()
 		switch {
 		case errors.Is(err, http.ErrServerClosed):
 			logger.Info("server stopped")
@@ -27,6 +27,6 @@ func (hf *heyFil) startServer() error {
 	return nil
 }
 
-func (hf *heyFil) shutdownServer(ctx context.Context) error {
-	return hf.server.Shutdown(ctx)
+func (hf *heyFil) shutdownMetricsServer(ctx context.Context) error {
+	return hf.metricsServer.Shutdown(ctx)
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,110 @@
+openapi: 3.0.3
+info:
+  version: 0.0.1
+  title: HeyFil Query API
+  description: API specification for the heyFil SP query service
+servers:
+  - url: http://localhost:8081
+paths:
+  /sp:
+    get:
+      summary: Get all SP IDs, optionally filter by peer ID
+      parameters:
+        - in: query
+          name: peerid
+          schema:
+            type: string
+          description: Optional filter by peer ID
+      responses:
+        '200':
+          description: An array of SP IDs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: Invalid peer ID supplied
+    options:
+      summary: Get allowed methods for /sp endpoint
+      responses:
+        '200':
+          description: Returns allowed methods
+  /sp/{id}:
+    get:
+      summary: Get detailed information about a specific SP by its ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The ID of the SP
+      responses:
+        '200':
+          description: The detailed SP information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  status:
+                    type: integer
+                    enum: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]
+                    description: |
+                      The status of the SP, where:
+                      0 = StatusUnknown,
+                      1 = StatusOK,
+                      2 = StatusAPICallFailed,
+                      3 = StatusInternalError,
+                      4 = StatusUnknownRPCError,
+                      5 = StatusNotMiner,
+                      6 = StatusUnreachable,
+                      7 = StatusUnaddressable,
+                      8 = StatusUnindexed,
+                      9 = StatusTopicMismatch,
+                      10 = StatusEmptyHead,
+                      11 = StatusGetHeadError,
+                      12 = StatusAnnounceError,
+                      13 = StatusUnidentifiable,
+                      14 = StatusNoAddrInfo
+                  addr_info:
+                    type: object
+                    properties:
+                      ID:
+                        type: string
+                      Addrs:
+                        type: array
+                        items:
+                          type: string
+                  last_checked:
+                    type: string
+                    format: date-time
+                  err:
+                    type: string
+                  topic:
+                    type: string
+                  head_protocol:
+                    type: string
+                  head:
+                    type: string
+                  known_by_indexer:
+                    type: boolean
+                  deal_count:
+                    type: integer
+                  deal_count_within_day:
+                    type: integer
+                  deal_count_within_week:
+                    type: integer
+        '400':
+          description: SP ID must be specified as URL parameter
+        '404':
+          description: SP not found
+    options:
+      summary: Get allowed methods for /sp/{id} endpoint
+      responses:
+        '200':
+          description: Returns allowed methods

--- a/options.go
+++ b/options.go
@@ -20,7 +20,8 @@ type (
 		participantsCheckInterval     *time.Ticker
 		dealStatsRefreshInterval      *time.Ticker
 		snapshotInterval              *time.Ticker
-		serverListenAddr              string
+		metricsListenAddr             string
+		apiListenAddr                 string
 		httpClient                    *http.Client
 		marketDealsS3Snapshot         string
 		marketDealsFilTools           string
@@ -41,7 +42,8 @@ func newOptions(o ...Option) (*options, error) {
 		participantsCheckInterval:     time.NewTicker(1 * time.Hour),
 		snapshotInterval:              time.NewTicker(10 * time.Second),
 		dealStatsRefreshInterval:      time.NewTicker(1 * time.Hour),
-		serverListenAddr:              "0.0.0.0:8080",
+		metricsListenAddr:             "0.0.0.0:8080",
+		apiListenAddr:                 "0.0.0.0:8081",
 	}
 	for _, apply := range o {
 		if err := apply(opts); err != nil {
@@ -114,11 +116,20 @@ func WithSnapshotInterval(t *time.Ticker) Option {
 	}
 }
 
-// WithListenAddr sets the listen address of the HTTP server on which metrics are reported.
+// WithMetricsListenAddr sets the listen address of the HTTP server on which metrics are reported.
 // Defaults to "0.0.0.0:8080
-func WithListenAddr(addr string) Option {
+func WithMetricsListenAddr(addr string) Option {
 	return func(o *options) error {
-		o.serverListenAddr = addr
+		o.metricsListenAddr = addr
+		return nil
+	}
+}
+
+// WithApiListenAddr sets the listen address of the HTTP server on which serves the HeyFil API.
+// Defaults to "0.0.0.0:8081
+func WithApiListenAddr(addr string) Option {
+	return func(o *options) error {
+		o.metricsListenAddr = addr
 		return nil
 	}
 }

--- a/target.go
+++ b/target.go
@@ -13,20 +13,20 @@ import (
 type (
 	Status int
 	Target struct {
-		hf             *heyFil
-		ID             string
-		Status         Status
-		AddrInfo       peer.AddrInfo
-		LastChecked    time.Time
-		Err            error
-		Topic          string
-		HeadProtocol   protocol.ID
-		Head           cid.Cid
-		KnownByIndexer bool
+		hf             *heyFil       `json:"-"`
+		ID             string        `json:"id,omitempty"`
+		Status         Status        `json:"status,omitempty"`
+		AddrInfo       peer.AddrInfo `json:"addr_info"`
+		LastChecked    time.Time     `json:"last_checked"`
+		Err            error         `json:"err,omitempty"`
+		Topic          string        `json:"topic,omitempty"`
+		HeadProtocol   protocol.ID   `json:"head_protocol,omitempty"`
+		Head           cid.Cid       `json:"head"`
+		KnownByIndexer bool          `json:"known_by_indexer,omitempty"`
 
-		DealCount           int64
-		DealCountWithinDay  int64
-		DealCountWithinWeek int64
+		DealCount           int64 `json:"deal_count,omitempty"`
+		DealCountWithinDay  int64 `json:"deal_count_within_day,omitempty"`
+		DealCountWithinWeek int64 `json:"deal_count_within_week,omitempty"`
 	}
 )
 


### PR DESCRIPTION
Add query APIs that:
* list all the SP IDs known by HeyFil, optionally filtered by libp2p peer ID
* get detailed information about a SP by its ID.

Define OpenAPI specification to document the query API.

Fixes #26