### PR TITLE
Implement local storage for resumable metrics

### DIFF
--- a/api_server.go
+++ b/api_server.go
@@ -51,7 +51,7 @@ func (hf *heyFil) handleSPRoot(w http.ResponseWriter, r *http.Request) {
 		hf.targetsMutex.RLock()
 		spIDs := make([]string, 0, len(hf.targets))
 		for id, target := range hf.targets {
-			if filterByPeerID && target.AddrInfo.ID != pidFilter {
+			if filterByPeerID && target.AddrInfo != nil && target.AddrInfo.ID != pidFilter {
 				continue
 			}
 			spIDs = append(spIDs, id)

--- a/main.go
+++ b/main.go
@@ -12,9 +12,14 @@ func main() {
 	// TODO: add flags for each of the options and pass to newHeyFil
 	httpIndexerEndpoint := flag.String("httpIndexerEndpoint", "https://cid.contact", "The HTTP IPNI endpoint to which announcements are made.")
 	maxConcurrentChecks := flag.Int("maxConcurrentChecks", 10, "The maximum number of concurrent checks.")
+	storePath := flag.String("storePath", "", "The directory to use for storing the discovered SP information.")
 	flag.Parse()
 
-	hf, err := newHeyFil(WithHttpIndexerEndpoint(*httpIndexerEndpoint), WithMaxConcurrentChecks(*maxConcurrentChecks))
+	hf, err := newHeyFil(
+		WithHttpIndexerEndpoint(*httpIndexerEndpoint),
+		WithMaxConcurrentChecks(*maxConcurrentChecks),
+		WithStorePath(*storePath),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -215,7 +215,7 @@ func (m *metrics) snapshot(targets map[string]*Target) {
 
 	for _, t := range targets {
 		countsByStatus[t.Status] = countsByStatus[t.Status] + 1
-		if t.AddrInfo.ID != "" && len(t.AddrInfo.Addrs) > 0 {
+		if t.AddrInfo != nil && t.AddrInfo.ID != "" && len(t.AddrInfo.Addrs) > 0 {
 			if t.DealCount > 0 {
 				if t.KnownByIndexer {
 					totalParticipantsKnownByIndexer++

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"path"
 	"regexp"
 	"time"
 
@@ -27,6 +28,7 @@ type (
 		marketDealsFilTools           string
 		marketDealsFilToolsEnabled    bool
 		httpIndexerEndpoint           string
+		storePath                     string
 	}
 )
 
@@ -139,6 +141,21 @@ func WithApiListenAddr(addr string) Option {
 func WithHttpIndexerEndpoint(url string) Option {
 	return func(o *options) error {
 		o.httpIndexerEndpoint = url
+		return nil
+	}
+}
+
+// WithStorePath sets the directory to use for storing the SP data.
+// The stored information is then used to reload the state on service restart if it is present.
+// Defaults to in-memory storage only, which means on each service restart
+// previous SP state is re-populated from scratch.
+func WithStorePath(p string) Option {
+	return func(o *options) error {
+		// Check if path is empty before cleaning it since cleaning an empty path results in ".",
+		// and empty path instead should disable local storage.
+		if p != "" {
+			o.storePath = path.Clean(p)
+		}
 		return nil
 	}
 }

--- a/store.go
+++ b/store.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func (hf *heyFil) store(t *Target) error {
+	if hf.storePath == "" || t == nil || t.ID == "" {
+		return nil
+	}
+	dest, err := os.OpenFile(path.Join(hf.storePath, t.ID+".json"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		logger.Errorw("Failed to open store file for target", "id", t.ID, "err", err)
+		return err
+	}
+	defer dest.Close()
+	return json.NewEncoder(dest).Encode(t)
+}
+func (hf *heyFil) loadTargets() error {
+	if hf.storePath == "" {
+		return nil
+	}
+	var totalLoaded int
+	hf.targetsMutex.Lock()
+	defer func() {
+		hf.targetsMutex.Unlock()
+		logger.Infow("finished loading SP information from store", "total", totalLoaded)
+	}()
+	return filepath.Walk(hf.storePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logger.Errorw("failed to access path", "path", path, "err", err)
+			return nil
+		}
+
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".json") {
+			source, err := os.Open(path)
+			if err != nil {
+				logger.Errorw("failed to open target file at path", "path", path, "err", err)
+				return nil
+			}
+
+			var target Target
+			if err := json.NewDecoder(source).Decode(&target); err != nil {
+				logger.Errorw("failed to decode target file at path", "path", path, "err", err)
+				return nil
+			}
+			hf.targets[target.ID] = &target
+			totalLoaded++
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Store collected SP information on disk such that on service restart data and stats is reloaded. This would avoid long wait in order of hours to wait for chain walk before metrics get populated.

Silently fall back on populating the metrics if loading the stored info for a SP fails.