### PR TITLE
track total bytes of storage (and deltas) per provider

### DIFF
--- a/fil_client.go
+++ b/fil_client.go
@@ -46,6 +46,7 @@ type (
 			Provider   string `json:"Provider"`
 			StartEpoch int64  `json:"StartEpoch"`
 			EndEpoch   int64  `json:"EndEpoch"`
+			PieceSize  int64  `json:"PieceSize"`
 		} `json:"Proposal"`
 		State struct {
 			SectorStartEpoch int64 `json:"SectorStartEpoch"`

--- a/fil_deal_stats.go
+++ b/fil_deal_stats.go
@@ -24,8 +24,11 @@ type (
 	}
 	dealCounts struct {
 		count           int64
+		bytes           int64
 		countWithinDay  int64
+		bytesWithinDay  int64
 		countWithinWeek int64
+		bytesWithinWeek int64
 	}
 )
 
@@ -89,14 +92,17 @@ func (ds *dealStats) refresh(ctx context.Context) error {
 				provider := dr.Deal.Proposal.Provider
 				providerDealCount := dealCountByParticipant[provider]
 				providerDealCount.count++
+				providerDealCount.bytes += dr.Deal.Proposal.PieceSize
 				elapsedSinceStartEpoch := currentEpoch - dr.Deal.Proposal.StartEpoch
 				if elapsedSinceStartEpoch < filEpochDay {
 					totalDealCountWithinDay++
 					providerDealCount.countWithinDay++
+					providerDealCount.bytesWithinDay += dr.Deal.Proposal.PieceSize
 				}
 				if elapsedSinceStartEpoch < filEpochWeek {
 					totalDealCountWithinWeek++
 					providerDealCount.countWithinWeek++
+					providerDealCount.bytesWithinWeek += dr.Deal.Proposal.PieceSize
 				}
 				dealCountByParticipant[provider] = providerDealCount
 			}


### PR DESCRIPTION
in addition to deal counts, it'll be useful to get amount of data being held actively by each SP.